### PR TITLE
DB への問い合わせの削減(N+1対策)-NO1

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,6 @@
 
 class ProductsController < ApplicationController
   def index
-    @products = Product.all
+    @products = Product.includes(category: :category_setting_items).all
   end
 end


### PR DESCRIPTION
`categories`テーブルと`category_setting_items`テーブルを予め読み込んでおき、キャッシュさせておくことで、
`categories`テーブルと`category_setting_items`テーブルへのDBアクセス回数を減らしました。

`includes`については以下の記事がわかりやすいです。
https://qiita.com/k0kubun/items/80c5a5494f53bb88dc58