### PR TITLE
DB への問い合わせの削減(N+1対策)-NO2

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,6 @@
 
 class ProductsController < ApplicationController
   def index
-    @products = Product.includes(category: :category_setting_items).all
+    @products = Product.includes(:product_category_settings, [category: :category_setting_items]).all
   end
 end

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -6,6 +6,7 @@ h1 = "ProductsController#Index"
   h3
     = "[product.name] #{product.name}"
   dl.row
+    - enabled_category_setting_item_ids = product.product_category_settings.filter { |v| v.enabled }.map(&:category_setting_item_id)
     - product.category.category_setting_items.each do |item|
       dt.col-sm-3 = item.name
-      dd.col-sm-3 = CategorySettingItem.fetch_category_setting_data(product_id: product.id, category_setting_item_id: item.id)&.enabled ? "設定中" : "未設定"
+      dd.col-sm-3 = enabled_category_setting_item_ids.include?(item.id) ? "設定中" : "未設定"


### PR DESCRIPTION
#### 改善
1. product_category_settingsテーブルを予め読み込んでおき、キャッシュさせておくことで、
product_category_settingsテーブルへのDBアクセス回数を減らしました。

2. ViewのなかでSQLを発行する処理になっていたので、`product.product_category_settings`が`enabled`なオブジェクトに絞り込み、対象のオブジェクトの`category_setting_item_id`を配列に一旦格納し、その配列ないに対象のidが存在するかどうかの処理に書き換えました。

#### 補足
また
```ruby 
CategorySettingItem.fetch_category_setting_data(product_id: product.id, category_setting_item_id: item.id)
```
は命名も含め、筋が悪い関数なのですが、実際にそれっぽい名前で内部でSQLが存在することがあるので、
想定していないSQLが発行されている場合は、呼び出している関数の処理を疑いましょう。

そもそもViewのなかでSQLを発行するのは良くないので(loopの中で呼び出すのはもっと良くない)、
そういう処理を書かないといけない時は、設計を疑うか、もしくは自分のコードの筋が良いか一旦冷静に見直しましょう。

(参考に定義してあるfetch_category_setting_data関数)
```ruby
class CategorySettingItem < ApplicationRecord
  belongs_to :category
  has_many :product_category_settings

  class << self
    def fetch_category_setting_data(product_id:, category_setting_item_id:)
      ProductCategorySetting.find_by(product_id: product_id, category_setting_item_id: category_setting_item_id)
    end
  end
end
```
