### PR TITLE
viewのコンポーネント化

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,6 +2,6 @@
 
 class CategoriesController < ApplicationController
   def index
-    @categories = Category.all
+    @categories = Category.includes(:category_setting_items, [products: :product_category_settings]).all
   end
 end

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -1,12 +1,4 @@
 h1 = "CategoriesController#Index"
 - @categories&.each do |category|
   - category.products.each do |product|
-    h2
-      = "[category.id] #{category.id}"
-      = "[category.name] #{category.name}"
-    h3
-      = "[product.name] #{product.name}"
-    dl.row
-      - product.category.category_setting_items.each do |item|
-        dt.col-sm-3 = item.name
-        dd.col-sm-3 = CategorySettingItem.fetch_category_setting_data(category_setting_item_id: item.id)&.enabled ? "設定中" : "未設定"
+    == render partial: 'partials/product_setting', locals: { product: product }

--- a/app/views/partials/_product_setting.html.slim
+++ b/app/views/partials/_product_setting.html.slim
@@ -1,0 +1,10 @@
+h2
+  = "[category.id] #{product.category.id}"
+  = "[category.name] #{product.category.name}"
+h3
+  = "[product.name] #{product.name}"
+dl.row
+  - enabled_category_setting_item_ids = product.product_category_settings.filter { |v| v.enabled }.map(&:category_setting_item_id)
+  - product.category.category_setting_items.each do |item|
+    dt.col-sm-3 = item.name
+    dd.col-sm-3 = enabled_category_setting_item_ids.include?(item.id) ? "設定中" : "未設定"

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -1,12 +1,3 @@
 h1 = "ProductsController#Index"
 - @products&.each do |product|
-  h2
-    = "[category.id] #{product.category.id}"
-    = "[category.name] #{product.category.name}"
-  h3
-    = "[product.name] #{product.name}"
-  dl.row
-    - enabled_category_setting_item_ids = product.product_category_settings.filter { |v| v.enabled }.map(&:category_setting_item_id)
-    - product.category.category_setting_items.each do |item|
-      dt.col-sm-3 = item.name
-      dd.col-sm-3 = enabled_category_setting_item_ids.include?(item.id) ? "設定中" : "未設定"
+  == render partial: 'partials/product_setting', locals: { product: product }


### PR DESCRIPTION
1. `/products`と`categories`で同じ内容を表示させていたので、コンポーネント化し共通で呼び出せるようにしました
2. 共通化したことにより、N+1の発生箇所を見つけたのでついでに修正しました。